### PR TITLE
Treat errors as app insights exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,15 @@ silly          | verbose (0)
 
 [0]: https://azure.microsoft.com/en-us/services/application-insights/
 [1]: https://github.com/flatiron/winston
+
+## Treating errors as Exceptions
+
+When the log level is >= `error`, the transport will also treat it as an app insights Exception. This allows you to see it clearly in the Azure Application Insights instead of having to access trace information manually and set up alerts based on the related metrics.
+
+How it works:
+
+* `winstonLogger.log('error', 'error message');` will trigger an app insights `trackException` with `Error('error message')` as argument
+
+* `winstonLogger.log('error', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument
+
+* `winstonLogger.log('error', 'error message', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument

--- a/lib/winston-azure-application-insights.js
+++ b/lib/winston-azure-application-insights.js
@@ -108,6 +108,19 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 		return callback(null, true); 
 	} 
 
+	var aiLevel = getMessageLevel(level);
+	if (aiLevel >= getMessageLevel('error')) {
+		var error;
+		if (msg instanceof Error) {
+			error = msg;
+		} else if (meta instanceof Error) {
+			error = meta;
+		} else {
+			error = Error(msg);
+		}
+		this.client.trackException(error);
+	}
+
 	if (meta instanceof Error) {
 		var errorMeta = {
 			stack: meta.stack,
@@ -128,10 +141,9 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 		meta = errorMeta;
 	}
 
-	this.client.trackTrace(msg, getMessageLevel(level), meta);
+	this.client.trackTrace(msg, aiLevel, meta);
 	
 	return callback(null, true);
 };
 
 exports.AzureApplicationInsightsLogger = AzureApplicationInsightsLogger;
- 


### PR DESCRIPTION
When the log level is >= `error`, the transport will also treat it as an app insights Exception.
This allows you to see it clearly in the Azure Application Insights instead of having to access trace information manually and set up alerts based on the related metrics.

How it works:
- `winstonLogger.log('error', 'error message');` will trigger an app insights `trackException` with `Error('error message')` as argument
- `winstonLogger.log('error', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument
- `winstonLogger.log('error', 'error message', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument
